### PR TITLE
59 immutable refresh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,6 @@
             <version>${stups-spring-oauth2-support.version}</version>
         </dependency>
 
-        <!-- Why do we need this? -->
-        <dependency>
-            <groupId>org.zalando.stups</groupId>
-            <artifactId>tokens</artifactId>
-            <version>0.9.9</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,10 @@
             <version>19.0</version>
         </dependency>
         <dependency>
-            <groupId>com.google.auto.value</groupId>
-            <artifactId>auto-value</artifactId>
-            <version>1.1</version>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <version>2.1.15</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/org/zalando/planb/revocation/Main.java
+++ b/src/main/java/org/zalando/planb/revocation/Main.java
@@ -6,7 +6,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.velocity.VelocityAutoConfiguration;
 
 @SpringBootApplication
-@EnableAutoConfiguration(exclude = VelocityAutoConfiguration.class) // Needed because of Google AutoValue (WTF?)
 public class Main {
 
     public static void main(final String[] args) throws Exception {

--- a/src/main/java/org/zalando/planb/revocation/domain/Refresh.java
+++ b/src/main/java/org/zalando/planb/revocation/domain/Refresh.java
@@ -1,41 +1,30 @@
 package org.zalando.planb.revocation.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
 import org.zalando.planb.revocation.util.UnixTimestamp;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import com.google.auto.value.AutoValue;
-
 /**
- * Represents a notification to refresh all revocations since a point in time.
+ * A notification to refresh all revocations since an instant in time.
  *
- * @author  <a href="mailto:rodrigo.reis@zalando.de">Rodrigo Reis</a>
+ * @author <a href="mailto:rodrigo.reis@zalando.de">Rodrigo Reis</a>
  */
-@AutoValue
+@Value.Immutable
+@JsonSerialize
+@JsonDeserialize(as = ImmutableRefresh.class)
 public abstract class Refresh {
-
-    Refresh() { } // Avoid subclassing
-
-    @JsonCreator
-    public static Refresh create(@JsonProperty("refresh_from") final Integer refreshFrom,
-            @JsonProperty("refresh_timestamp") final Integer refreshTimestamp) {
-        return new AutoValue_Refresh(refreshFrom, refreshTimestamp != null ? refreshTimestamp : UnixTimestamp.now());
-    }
-
-    public static Refresh create(final Integer refreshFrom) {
-        return create(refreshFrom, UnixTimestamp.now());
-    }
 
     /**
      * The instant from when to refresh notifications, in UTC UNIX timestamp.
      */
-    @JsonProperty("refresh_from")
     public abstract Integer refreshFrom();
 
     /**
-     * The instant that this refresh notification was created, in UTC UNIX Timestamp.
+     * The instant that this refresh notification was created, in UTC UNIX Timestamp. Defaults to the current timestamp.
      */
-    @JsonProperty("refresh_timestamp")
-    public abstract Integer refreshTimestamp();
+    @Value.Default
+    public Integer refreshTimestamp() {
+        return UnixTimestamp.now();
+    }
 }

--- a/src/main/java/org/zalando/planb/revocation/persistence/InMemoryStore.java
+++ b/src/main/java/org/zalando/planb/revocation/persistence/InMemoryStore.java
@@ -6,6 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.zalando.planb.revocation.domain.ImmutableRefresh;
 import org.zalando.planb.revocation.domain.Refresh;
 import org.zalando.planb.revocation.domain.RevocationData;
 import org.zalando.planb.revocation.domain.RevocationRequest;
@@ -38,6 +39,7 @@ public class InMemoryStore implements RevocationStore {
 
     @Override
     public void storeRefresh(final int from) {
-        refreshNotifications.offer(Refresh.create(from));
+
+        refreshNotifications.offer(ImmutableRefresh.builder().refreshFrom(from).build());
     }
 }

--- a/src/main/java/org/zalando/planb/revocation/persistence/RevocationStore.java
+++ b/src/main/java/org/zalando/planb/revocation/persistence/RevocationStore.java
@@ -1,10 +1,10 @@
 package org.zalando.planb.revocation.persistence;
 
-import java.util.Collection;
-
 import org.zalando.planb.revocation.domain.Refresh;
 import org.zalando.planb.revocation.domain.RevocationData;
 import org.zalando.planb.revocation.domain.RevocationRequest;
+
+import java.util.Collection;
 
 /**
  * Created by jmussler on 11.02.16.
@@ -16,26 +16,23 @@ public interface RevocationStore {
     /**
      * Stores the specified revocation data into the store.
      *
-     * @param revocation    the revocation to store
-     * @return  {@code true} if the opertion was successful, {@code false} otherwise
+     * @param revocation the revocation to store
      */
     void storeRevocation(RevocationRequest revocation);
 
     /**
      * Returns the latest refresh notification.
      *
-     * @return  the latest refresh notification.
+     * @return the latest refresh notification.
      */
     Refresh getRefresh();
 
     /**
      * Stores the specified timestamp as a refresh notification.
-     *
+     * <p>
      * <p>The {@link Refresh} object stored will be the latest in the list of refresh notifications.</p>
      *
-     * @param   from  UTC UNIX timestamp from when to refresh revocations.
-     *
-     * @return  {@code true} if the operation was successful, {@code false} otherwise.
+     * @param from UTC UNIX timestamp from when to refresh revocations.
      */
     void storeRefresh(int from);
 }

--- a/src/test/java/org/zalando/planb/revocation/domain/DomainTests.java
+++ b/src/test/java/org/zalando/planb/revocation/domain/DomainTests.java
@@ -24,56 +24,6 @@ public class DomainTests {
     private static final int ONE_MINUTE_BEFORE = 1457568706;
 
     /**
-     * Tests that when instantiating a {@link Refresh} all values are set, including defaults.
-     */
-    @Test
-    public void testDefaultRefresh() {
-
-        Refresh r = Refresh.create(ONE_HOUR_BEFORE);
-        assertThat(r.refreshFrom()).isEqualTo(ONE_HOUR_BEFORE);
-        assertThat(r.refreshTimestamp()).isNotNull();
-    }
-
-    /**
-     * Tests assigning a timestamp to a {@link Refresh} object.
-     */
-    @Test
-    public void testRefreshWithTimestamp() {
-
-        Refresh r = Refresh.create(ONE_HOUR_BEFORE, ONE_MINUTE_BEFORE);
-        assertThat(r.refreshTimestamp()).isEqualTo(ONE_MINUTE_BEFORE);
-    }
-
-    /**
-     * Tests JSON serialization of {@link Refresh} objects.
-     */
-    @Test
-    public void testRefreshJsonSerialization() throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
-        String expected = "{\"refresh_from\":1458232925,\"refresh_timestamp\":1458232985}";
-
-        Refresh refresh = Refresh.create(1458232925, 1458232985);
-
-        String serialized = mapper.writeValueAsString(refresh);
-
-        assertThat(serialized).isEqualTo(expected);
-    }
-
-    /**
-     * Tests JSON deserialization of {@link Refresh} objects.
-     */
-    @Test
-    public void testRefreshJsonDeserialization() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        String json = "{\"refresh_from\":1458232925,\"refresh_timestamp\":1458232985}";
-
-        Refresh deserialized = mapper.readValue(json, Refresh.class);
-
-        assertThat(deserialized.refreshFrom()).isEqualTo(1458232925);
-        assertThat(deserialized.refreshTimestamp()).isEqualTo(1458232985);
-    }
-
-    /**
      * Tests that a default timestamp is set in {@link RevokedClaimsData#issuedBefore} when creating a new instance.
      */
     @Test

--- a/src/test/java/org/zalando/planb/revocation/domain/RefreshTest.java
+++ b/src/test/java/org/zalando/planb/revocation/domain/RefreshTest.java
@@ -1,0 +1,90 @@
+package org.zalando.planb.revocation.domain;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.zalando.planb.revocation.config.PlanBRevocationConfig;
+import org.zalando.planb.revocation.util.InstantTimestamp;
+import org.zalando.planb.revocation.util.UnixTimestamp;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for refresh notifications.
+ *
+ * @author <a href="mailto:rodrigo.reis@zalando.de">Rodrigo Reis</a>
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = PlanBRevocationConfig.class)
+public class RefreshTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final Integer REFRESH_FROM = InstantTimestamp.FIVE_MINUTES_AGO.seconds();
+
+    private static final Integer REFRESH_TIMESTAMP = InstantTimestamp.NOW.seconds();
+
+    private static final String SERIALIZED_REFRESH = "{\"refresh_from\":" + REFRESH_FROM + "," +
+            "\"refresh_timestamp\":" + REFRESH_TIMESTAMP + "}";
+
+    private static final String SERIALIZED_REFRESH_WITHOUT_TIMESTAMP = "{\"refresh_from\":" + REFRESH_FROM + "}";
+
+    /**
+     * Tests that when instantiating a {@link Refresh} all values are set, including a default timestamp.
+     */
+    @Test
+    public void testDefaultTimestamp() {
+        Refresh notification = ImmutableRefresh.builder().refreshFrom(InstantTimestamp
+                .FIVE_MINUTES_AGO.seconds()).build();
+
+        assertThat(notification.refreshTimestamp()).isNotNull();
+        assertThat(notification.refreshTimestamp()).isLessThanOrEqualTo(UnixTimestamp.now());
+    }
+
+    /**
+     * Tests JSON serialization of a {@link Refresh} object.
+     */
+    @Test
+    public void testJsonSerialization() throws IOException {
+        Integer refreshFrom = InstantTimestamp.FIVE_MINUTES_AGO.seconds();
+        Integer refreshTimestamp = InstantTimestamp.NOW.seconds();
+
+        Refresh notification = ImmutableRefresh.builder().refreshFrom(refreshFrom)
+                .refreshTimestamp(refreshTimestamp).build();
+
+        String serialized = objectMapper.writeValueAsString(notification);
+        assertThat(serialized).isEqualTo(SERIALIZED_REFRESH);
+    }
+
+    /**
+     * Tests JSON deserialization of a {@link Refresh} object.
+     */
+    @Test
+    public void testJsonDeserialization() throws IOException {
+
+        Refresh notification = objectMapper.readValue(SERIALIZED_REFRESH, Refresh.class);
+
+        assertThat(notification.refreshFrom()).isEqualTo(REFRESH_FROM);
+        assertThat(notification.refreshTimestamp()).isEqualTo(REFRESH_TIMESTAMP);
+    }
+
+    /**
+     * Tests JSON deserialization of a {@link Refresh} object when the serialized string does not have a timestamp
+     * value.
+     */
+    @Test
+    public void testJsonDeserializationWithoutTimestamp() throws IOException {
+
+        Refresh notification = objectMapper.readValue(SERIALIZED_REFRESH_WITHOUT_TIMESTAMP, Refresh.class);
+
+        assertThat(notification.refreshFrom()).isEqualTo(REFRESH_FROM);
+        assertThat(notification.refreshTimestamp()).isNotNull();
+        assertThat(notification.refreshTimestamp()).isLessThanOrEqualTo(UnixTimestamp.now());
+    }
+}

--- a/src/test/java/org/zalando/planb/revocation/util/security/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/org/zalando/planb/revocation/util/security/WithMockCustomUserSecurityContextFactory.java
@@ -1,6 +1,6 @@
 package org.zalando.planb.revocation.util.security;
 
-import autovalue.shaded.com.google.common.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;


### PR DESCRIPTION
Lombok, besides lowering code coverage, does not have builder support for default values. I tried using Google's [AutoValue](https://github.com/google/auto/tree/master/value) - which support both -, but lacks proper Jackson support.

Yesterday I made tests with another library, [Immutables](http://immutables.github.io/). Not only has proper support for default values, but also has Jackson support included, and it makes really easy to write simple immutable POJO's without boilerplate - this, without lowering Code Coverage (it uses annotation processors to generated the code).

Example for force Refresh POJO:
- [POJO definition](https://github.com/zalando/planb-revocation/blob/59-immutable-refresh/src/main/java/org/zalando/planb/revocation/domain/Refresh.java)
- [Builder usage](https://github.com/zalando/planb-revocation/blob/59-immutable-refresh/src/main/java/org/zalando/planb/revocation/persistence/CassandraStore.java#L260)
- [Unit Tests](https://github.com/zalando/planb-revocation/blob/59-immutable-refresh/src/test/java/org/zalando/planb/revocation/domain/RefreshTest.java)

