### PR TITLE
52 handle cassandra outage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,9 @@
                             <startNativeTransport>true</startNativeTransport>
                             <cqlVersion>3.0.0</cqlVersion>
                             <script>revocation_schema.cql</script>
+                            <yaml>authenticator: PasswordAuthenticator</yaml>
+                            <username>cassandra</username>
+                            <password>cassandra</password>
                             <!--<cqlScript>src/test/resources/testdata.cql</cqlScript>-->
                             <!--
                             <systemPropertyVariables>

--- a/src/main/java/org/zalando/planb/revocation/Main.java
+++ b/src/main/java/org/zalando/planb/revocation/Main.java
@@ -2,10 +2,10 @@ package org.zalando.planb.revocation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.velocity.VelocityAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
 
-@SpringBootApplication
+@Configuration
+@EnableAutoConfiguration
 public class Main {
 
     public static void main(final String[] args) throws Exception {

--- a/src/main/java/org/zalando/planb/revocation/config/CassandraConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/CassandraConfig.java
@@ -8,14 +8,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.zalando.planb.revocation.config.properties.CassandraProperties;
 
 import java.util.Optional;
 
 @Configuration
 @EnableConfigurationProperties(CassandraProperties.class)
+@Order(CassandraConfig.ORDER)
 public class CassandraConfig {
 
+    static final int ORDER = 0;
 
     @Autowired
     private CassandraProperties cassandraProperties;

--- a/src/main/java/org/zalando/planb/revocation/config/CassandraConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/CassandraConfig.java
@@ -8,17 +8,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 import org.zalando.planb.revocation.config.properties.CassandraProperties;
 
 import java.util.Optional;
 
 @Configuration
 @EnableConfigurationProperties(CassandraProperties.class)
-@Order(CassandraConfig.ORDER)
 public class CassandraConfig {
-
-    static final int ORDER = 0;
 
     @Autowired
     private CassandraProperties cassandraProperties;

--- a/src/main/java/org/zalando/planb/revocation/config/CassandraConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/CassandraConfig.java
@@ -1,0 +1,46 @@
+package org.zalando.planb.revocation.config;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.policies.AddressTranslator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.zalando.planb.revocation.config.properties.CassandraProperties;
+
+import java.util.Optional;
+
+@Configuration
+@EnableConfigurationProperties(CassandraProperties.class)
+public class CassandraConfig {
+
+
+    @Autowired
+    private CassandraProperties cassandraProperties;
+
+    @Autowired
+    private Optional<AddressTranslator> addressTranslator;
+
+    @Bean
+    @ConditionalOnProperty(prefix = "cassandra", name = "contact-points")
+    public Session cassandraSession() {
+
+        // Build Cluster
+        final Cluster.Builder builder = Cluster.builder();
+        builder.addContactPoints(cassandraProperties.getContactPoints().split(","));
+        addressTranslator.ifPresent(builder::withAddressTranslator);
+        builder.withClusterName(cassandraProperties.getClusterName());
+        builder.withPort(cassandraProperties.getPort());
+
+        // Only set credentials if they exist
+        if (cassandraProperties.getUsername().isPresent() && cassandraProperties.getPassword().isPresent()) {
+            builder.withCredentials(cassandraProperties.getUsername().get(), cassandraProperties.getPassword().get());
+        }
+
+        return builder.build().connect(cassandraProperties.getKeyspace());
+    }
+
+
+}

--- a/src/main/java/org/zalando/planb/revocation/config/PlanBRevocationConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/PlanBRevocationConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zalando.planb.revocation.config.properties.ApiGuildProperties;
@@ -27,8 +28,8 @@ public class PlanBRevocationConfig {
     }
 
     @Bean
-    public SwaggerService swaggerService() {
-        return new SwaggerFromYamlFileService(apiGuildProperties.getSwaggerFile());
+    public SwaggerService swaggerService(ApplicationContext context) {
+        return new SwaggerFromYamlFileService(context, apiGuildProperties.getSwaggerFile());
     }
 
     @Bean

--- a/src/main/java/org/zalando/planb/revocation/config/RevocationConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/RevocationConfig.java
@@ -4,9 +4,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.zalando.planb.revocation.config.properties.CassandraProperties;
 import org.zalando.planb.revocation.config.properties.HashingProperties;
 import org.zalando.planb.revocation.config.properties.RevocationProperties;
 import org.zalando.planb.revocation.domain.RevocationType;
+import org.zalando.planb.revocation.persistence.AuthorizationRulesStore;
+import org.zalando.planb.revocation.service.RevocationAuthorizationService;
+import org.zalando.planb.revocation.service.impl.RuleBasedClaimRevocationAuthorizationService;
 import org.zalando.planb.revocation.util.ImmutableMessageHasher;
 import org.zalando.planb.revocation.util.MessageHasher;
 
@@ -14,7 +18,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Configuration
 @EnableConfigurationProperties({HashingProperties.class, RevocationProperties.class})
@@ -35,5 +38,13 @@ public class RevocationConfig {
                 .salt(hashingProperties.getSalt())
                 .separator(hashingProperties.getSeparator())
                 .build();
+    }
+
+    @Bean
+    public RevocationAuthorizationService revocationAuthorizationService(
+            AuthorizationRulesStore authorizationRulesStore,
+            RevocationProperties revocationProperties,
+            CassandraProperties cassandraProperties) {
+        return new RuleBasedClaimRevocationAuthorizationService(authorizationRulesStore, revocationProperties, cassandraProperties);
     }
 }

--- a/src/main/java/org/zalando/planb/revocation/config/SecurityConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.oauth2.provider.token.ResourceServerTokenSer
 import org.springframework.security.web.header.writers.HstsHeaderWriter;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.zalando.planb.revocation.config.properties.ApiSecurityProperties;
+import org.zalando.planb.revocation.domain.CurrentUser;
 import org.zalando.stups.oauth2.spring.security.expression.ExtendedOAuth2WebSecurityExpressionHandler;
 import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
 
@@ -70,5 +71,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter implements Reso
 
     private HstsHeaderWriter hstsHeaderWriter() {
         return new HstsHeaderWriter(AnyRequestMatcher.INSTANCE, TimeUnit.DAYS.toSeconds(365), true);
+    }
+
+    @Bean
+    public CurrentUser currentUser(){
+        return new CurrentUser();
     }
 }

--- a/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
@@ -2,11 +2,12 @@ package org.zalando.planb.revocation.config;
 
 import com.datastax.driver.core.Session;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
+import org.springframework.context.annotation.Import;
 import org.zalando.planb.revocation.config.properties.CassandraProperties;
 import org.zalando.planb.revocation.management.CassandraHealthIndicator;
 import org.zalando.planb.revocation.persistence.AuthorizationRulesStore;
@@ -17,13 +18,13 @@ import org.zalando.planb.revocation.persistence.InMemoryRevocationStore;
 import org.zalando.planb.revocation.persistence.RevocationStore;
 
 @Configuration
-@Order(CassandraConfig.ORDER + 1)
+@AutoConfigureAfter(CassandraConfig.class)
+@Import(CassandraConfig.class)
 public class StorageConfig {
 
     @Configuration
     @ConditionalOnBean(Session.class)
-    @Order(CassandraConfig.ORDER + 1)
-    public static class CassandraStorageConfig {
+    static class CassandraStorageConfig {
 
         @Autowired
         private CassandraProperties cassandraProperties;
@@ -51,8 +52,7 @@ public class StorageConfig {
 
     @Configuration
     @ConditionalOnMissingBean(Session.class)
-    @Order(CassandraConfig.ORDER + 1)
-    public static class InMemoryStorageConfig {
+    static class InMemoryStorageConfig {
 
         @Bean
         public RevocationStore revocationStore() {

--- a/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
@@ -2,6 +2,7 @@ package org.zalando.planb.revocation.config;
 
 import com.datastax.driver.core.Session;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +17,7 @@ import org.zalando.planb.revocation.persistence.InMemoryRevocationStore;
 import org.zalando.planb.revocation.persistence.RevocationStore;
 
 @Configuration
+@AutoConfigureAfter(CassandraConfig.class)
 public class StorageConfig {
 
     @Configuration

--- a/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
@@ -1,14 +1,15 @@
 package org.zalando.planb.revocation.config;
 
 import com.datastax.driver.core.Session;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.zalando.planb.revocation.config.properties.CassandraProperties;
+import org.zalando.planb.revocation.domain.CurrentUser;
 import org.zalando.planb.revocation.management.CassandraHealthIndicator;
 import org.zalando.planb.revocation.persistence.AuthorizationRulesStore;
 import org.zalando.planb.revocation.persistence.CassandraAuthorizationRuleStore;
@@ -19,7 +20,6 @@ import org.zalando.planb.revocation.persistence.RevocationStore;
 
 @Configuration
 @AutoConfigureAfter(CassandraConfig.class)
-@Import(CassandraConfig.class)
 public class StorageConfig {
 
     @Configuration
@@ -33,9 +33,10 @@ public class StorageConfig {
         private Session session;
 
         @Bean
-        public RevocationStore revocationStore() {
+        public RevocationStore revocationStore(final CurrentUser currentUser, final ObjectMapper objectMapper) {
             return new CassandraRevocationStore(session, cassandraProperties.getReadConsistencyLevel(),
-                    cassandraProperties.getWriteConsistencyLevel(), cassandraProperties.getMaxTimeDelta());
+                    cassandraProperties.getWriteConsistencyLevel(), cassandraProperties.getMaxTimeDelta(),
+                    currentUser, objectMapper);
         }
 
         @Bean

--- a/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
@@ -1,14 +1,13 @@
 package org.zalando.planb.revocation.config;
 
-import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
-import com.datastax.driver.core.policies.AddressTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.StringUtils;
 import org.zalando.planb.revocation.config.properties.CassandraProperties;
+import org.zalando.planb.revocation.management.CassandraHealthIndicator;
 import org.zalando.planb.revocation.persistence.AuthorizationRulesStore;
 import org.zalando.planb.revocation.persistence.CassandraAuthorizationRuleStore;
 import org.zalando.planb.revocation.persistence.CassandraRevocationStore;
@@ -16,64 +15,50 @@ import org.zalando.planb.revocation.persistence.InMemoryAuthorizationRuleStore;
 import org.zalando.planb.revocation.persistence.InMemoryRevocationStore;
 import org.zalando.planb.revocation.persistence.RevocationStore;
 
-import java.util.Optional;
-
 @Configuration
-@EnableConfigurationProperties(CassandraProperties.class)
 public class StorageConfig {
 
-    @Autowired
-    private CassandraProperties cassandraProperties;
+    @Configuration
+    @ConditionalOnBean(Session.class)
+    public static class CassandraStorageConfig {
 
-    @Autowired
-    private Optional<AddressTranslator> addressTranslator;
+        @Autowired
+        private CassandraProperties cassandraProperties;
 
-    /**
-     * Storage used for revocations.
-     * <p>
-     * <p>If no {@link CassandraProperties} are defined, defaults to in-memory storage.</p>
-     *
-     * @return the resulting {@code RevocationStore}
-     * @see CassandraProperties
-     */
-    @Bean
-    public RevocationStore revocationStore() {
+        @Autowired
+        private Session session;
 
-        // Defaults to in-memory, when CassandraProperties are absent;
-        if (StringUtils.isEmpty(cassandraProperties.getContactPoints())) {
+        @Bean
+        public RevocationStore revocationStore() {
+            return new CassandraRevocationStore(session, cassandraProperties.getReadConsistencyLevel(),
+                    cassandraProperties.getWriteConsistencyLevel(), cassandraProperties.getMaxTimeDelta());
+        }
+
+        @Bean
+        public AuthorizationRulesStore authorizationRulesStore() {
+            return new CassandraAuthorizationRuleStore(session, cassandraProperties.getReadConsistencyLevel(),
+                    cassandraProperties.getWriteConsistencyLevel());
+        }
+
+        @Bean
+        public CassandraHealthIndicator cassandraHealthIndicator() {
+            return new CassandraHealthIndicator(session, cassandraProperties);
+        }
+    }
+
+    @Configuration
+    @ConditionalOnMissingBean(Session.class)
+    public static class InMemoryStorageConfig {
+
+        @Bean
+        public RevocationStore revocationStore() {
             return new InMemoryRevocationStore();
         }
 
-        return new CassandraRevocationStore(cassandraSession(), cassandraProperties.getReadConsistencyLevel(),
-                cassandraProperties.getWriteConsistencyLevel(), cassandraProperties.getMaxTimeDelta());
-    }
-
-    @Bean
-    public AuthorizationRulesStore authorizationRulesStore() {
-
-        // Defaults to in-memory, when CassandraProperties are absent;
-        if (StringUtils.isEmpty(cassandraProperties.getContactPoints())) {
+        @Bean
+        public AuthorizationRulesStore authorizationRulesStore() {
             return new InMemoryAuthorizationRuleStore();
         }
-
-        return new CassandraAuthorizationRuleStore(cassandraSession(), cassandraProperties.getReadConsistencyLevel(),
-                cassandraProperties.getWriteConsistencyLevel());
     }
 
-    public Session cassandraSession() {
-
-        // Build Cluster
-        final Cluster.Builder builder = Cluster.builder();
-        builder.addContactPoints(cassandraProperties.getContactPoints().split(","));
-        addressTranslator.ifPresent(builder::withAddressTranslator);
-        builder.withClusterName(cassandraProperties.getClusterName());
-        builder.withPort(cassandraProperties.getPort());
-
-        // Only set credentials if they exist
-        if (cassandraProperties.getUsername().isPresent() && cassandraProperties.getPassword().isPresent()) {
-            builder.withCredentials(cassandraProperties.getUsername().get(), cassandraProperties.getPassword().get());
-        }
-
-        return builder.build().connect(cassandraProperties.getKeyspace());
-    }
 }

--- a/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
@@ -22,6 +22,7 @@ public class StorageConfig {
 
     @Configuration
     @ConditionalOnBean(Session.class)
+    @Order(CassandraConfig.ORDER + 1)
     public static class CassandraStorageConfig {
 
         @Autowired
@@ -50,6 +51,7 @@ public class StorageConfig {
 
     @Configuration
     @ConditionalOnMissingBean(Session.class)
+    @Order(CassandraConfig.ORDER + 1)
     public static class InMemoryStorageConfig {
 
         @Bean

--- a/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/StorageConfig.java
@@ -2,11 +2,11 @@ package org.zalando.planb.revocation.config;
 
 import com.datastax.driver.core.Session;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.zalando.planb.revocation.config.properties.CassandraProperties;
 import org.zalando.planb.revocation.management.CassandraHealthIndicator;
 import org.zalando.planb.revocation.persistence.AuthorizationRulesStore;
@@ -17,7 +17,7 @@ import org.zalando.planb.revocation.persistence.InMemoryRevocationStore;
 import org.zalando.planb.revocation.persistence.RevocationStore;
 
 @Configuration
-@AutoConfigureAfter(CassandraConfig.class)
+@Order(CassandraConfig.ORDER + 1)
 public class StorageConfig {
 
     @Configuration

--- a/src/main/java/org/zalando/planb/revocation/config/WebConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/WebConfig.java
@@ -1,16 +1,25 @@
 package org.zalando.planb.revocation.config;
 
+import com.codahale.metrics.MetricRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.zalando.planb.revocation.api.impl.ResponseSizeHandlerInterceptor;
-
-import com.codahale.metrics.MetricRegistry;
+import org.zalando.planb.revocation.web.RequestInfoMDCFilter;
 
 @Configuration
+@ComponentScan(
+        useDefaultFilters = false,
+        includeFilters = @Filter(classes = {Controller.class, RestController.class, ControllerAdvice.class}),
+        basePackages = "org.zalando.planb.revocation.api")
 public class WebConfig {
 
     @Autowired
@@ -26,5 +35,10 @@ public class WebConfig {
                         .addPathPatterns("/revocations");
             }
         };
+    }
+
+    @Bean
+    public RequestInfoMDCFilter requestInfoMDCFilter() {
+        return new RequestInfoMDCFilter();
     }
 }

--- a/src/main/java/org/zalando/planb/revocation/config/properties/CassandraProperties.java
+++ b/src/main/java/org/zalando/planb/revocation/config/properties/CassandraProperties.java
@@ -58,6 +58,8 @@ public class CassandraProperties {
     // Maybe this maxTimeDelta should be derived from the bucket size in Cassandra...
     private int maxTimeDelta = (int) Duration.ofDays(31).getSeconds();
 
+    private String healthCheckQuery = "SELECT release_version FROM system.local;";
+
     public String getKeyspace() {
         return keyspace;
     }
@@ -128,5 +130,13 @@ public class CassandraProperties {
 
     public void setMaxTimeDelta(int maxTimeDelta) {
         this.maxTimeDelta = maxTimeDelta;
+    }
+
+    public String getHealthCheckQuery() {
+        return healthCheckQuery;
+    }
+
+    public void setHealthCheckQuery(String healthCheckQuery) {
+        this.healthCheckQuery = healthCheckQuery;
     }
 }

--- a/src/main/java/org/zalando/planb/revocation/domain/CurrentUser.java
+++ b/src/main/java/org/zalando/planb/revocation/domain/CurrentUser.java
@@ -18,7 +18,6 @@ import java.util.function.Supplier;
  *
  * @author <a href="mailto:rodrigo.reis@zalando.de">Rodrigo Reis</a>
  */
-@Component
 public class CurrentUser implements Supplier<String> {
 
     private static final String FORMAT = "%s/%s";

--- a/src/main/java/org/zalando/planb/revocation/management/CassandraHealthIndicator.java
+++ b/src/main/java/org/zalando/planb/revocation/management/CassandraHealthIndicator.java
@@ -1,0 +1,39 @@
+package org.zalando.planb.revocation.management;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.zalando.planb.revocation.config.properties.CassandraProperties;
+
+import javax.annotation.PostConstruct;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class CassandraHealthIndicator extends AbstractHealthIndicator {
+
+    private final Session session;
+    private final CassandraProperties properties;
+    private Statement healthCheck;
+
+    public CassandraHealthIndicator(final Session session, final CassandraProperties properties) {
+        this.properties = properties;
+        this.session = checkNotNull(session, "Cassandra session must not be null");
+    }
+
+    @PostConstruct
+    public void initializeHealthCheck() {
+        this.healthCheck = this.session.prepare(properties.getHealthCheckQuery())
+                .setConsistencyLevel(properties.getReadConsistencyLevel())
+                .bind();
+    }
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) throws Exception {
+
+        // if this throws an exception the AbstractHealthIndicator implementation will report this indicator as "down".
+        session.execute(healthCheck);
+        builder.up();
+    }
+}
+

--- a/src/main/java/org/zalando/planb/revocation/persistence/CassandraRevocationStore.java
+++ b/src/main/java/org/zalando/planb/revocation/persistence/CassandraRevocationStore.java
@@ -11,7 +11,6 @@ import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.zalando.planb.revocation.api.exception.SerializationException;
 import org.zalando.planb.revocation.domain.CurrentUser;
 import org.zalando.planb.revocation.domain.ImmutableRefresh;
@@ -103,24 +102,25 @@ public class CassandraRevocationStore implements RevocationStore {
 
     private final Map<RevocationType, RevocationDataMapper> dataMappers = new EnumMap<>(RevocationType.class);
 
-    @Autowired
-    private CurrentUser currentUser;
+    private final CurrentUser currentUser;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     /**
      * Constructs a new instance configured with the provided {@code session} and {@code maxTimeDelta}.
-     *
-     * @param session      session configured to a Cassandra cluster
+     *  @param session      session configured to a Cassandra cluster
      * @param read         consistency level for SELECT queries
      * @param write        consistency level for INSERT queries
      * @param maxTimeDelta maximum time span limit to get revocations, in seconds
+     * @param currentUser currentUser supplier
+     * @param objectMapper the object mapper
      */
     public CassandraRevocationStore(final Session session, final ConsistencyLevel read, final ConsistencyLevel write,
-                                    final int maxTimeDelta) {
+                                    final int maxTimeDelta, final CurrentUser currentUser, final ObjectMapper objectMapper) {
         this.session = session;
         this.maxTimeDelta = maxTimeDelta;
+        this.currentUser = currentUser;
+        this.objectMapper = objectMapper;
 
         getFrom = session.prepare(SELECT_REVOCATION).setConsistencyLevel(read);
         insertRevocation = session.prepare(INSERT_REVOCATION).setConsistencyLevel(write);

--- a/src/main/java/org/zalando/planb/revocation/persistence/CassandraRevocationStore.java
+++ b/src/main/java/org/zalando/planb/revocation/persistence/CassandraRevocationStore.java
@@ -259,8 +259,10 @@ public class CassandraRevocationStore implements RevocationStore {
 
     @Override
     public void storeRefresh(final int from) {
-
         int yearBucket = LocalDate.now(ZoneId.of("UTC")).getYear();
+
+        LOG.debug("Store refresh in Cassandra yearBucket={} from={}", yearBucket, from);
+
         BoundStatement statement = storeRefresh.bind(yearBucket, UnixTimestamp.now(), from, currentUser.get());
         session.execute(statement);
     }

--- a/src/main/java/org/zalando/planb/revocation/persistence/InMemoryRevocationStore.java
+++ b/src/main/java/org/zalando/planb/revocation/persistence/InMemoryRevocationStore.java
@@ -1,5 +1,6 @@
 package org.zalando.planb.revocation.persistence;
 
+import org.slf4j.Logger;
 import org.zalando.planb.revocation.domain.ImmutableRefresh;
 import org.zalando.planb.revocation.domain.ImmutableRevocationData;
 import org.zalando.planb.revocation.domain.Refresh;
@@ -12,7 +13,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class InMemoryRevocationStore implements RevocationStore {
+
+    private final Logger log = getLogger(getClass());
 
     private final List<RevocationData> revocations = new ArrayList<>();
 
@@ -25,7 +30,9 @@ public class InMemoryRevocationStore implements RevocationStore {
 
     @Override
     public void storeRevocation(final RevocationRequest revocation) {
-        revocations.add(ImmutableRevocationData.builder().revocationRequest(revocation).build());
+        final RevocationData revocationData = ImmutableRevocationData.builder().revocationRequest(revocation).build();
+        log.debug("Store revocation in memory: {}", revocationData);
+        revocations.add(revocationData);
     }
 
     @Override
@@ -35,6 +42,8 @@ public class InMemoryRevocationStore implements RevocationStore {
 
     @Override
     public void storeRefresh(final int from) {
-        refreshNotifications.offer(ImmutableRefresh.builder().refreshFrom(from).build());
+        final Refresh refreshNotification = ImmutableRefresh.builder().refreshFrom(from).build();
+        log.debug("Store refresh in memory: {}", refreshNotification);
+        refreshNotifications.offer(refreshNotification);
     }
 }

--- a/src/main/java/org/zalando/planb/revocation/service/impl/AbstractAuthorizationService.java
+++ b/src/main/java/org/zalando/planb/revocation/service/impl/AbstractAuthorizationService.java
@@ -1,6 +1,5 @@
 package org.zalando.planb.revocation.service.impl;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.zalando.planb.revocation.api.exception.AncientRevocationException;
@@ -17,11 +16,14 @@ import org.zalando.planb.revocation.util.UnixTimestamp;
 
 public abstract class AbstractAuthorizationService implements RevocationAuthorizationService {
 
-    @Autowired
-    private RevocationProperties revocationProperties;
+    private final RevocationProperties revocationProperties;
 
-    @Autowired
-    private CassandraProperties cassandraProperties;
+    private final CassandraProperties cassandraProperties;
+
+    protected AbstractAuthorizationService(RevocationProperties revocationProperties, CassandraProperties cassandraProperties) {
+        this.revocationProperties = revocationProperties;
+        this.cassandraProperties = cassandraProperties;
+    }
 
     @Override
     public void checkAuthorization(final RevocationRequest revocationRequest) {

--- a/src/main/java/org/zalando/planb/revocation/service/impl/RuleBasedClaimRevocationAuthorizationService.java
+++ b/src/main/java/org/zalando/planb/revocation/service/impl/RuleBasedClaimRevocationAuthorizationService.java
@@ -1,13 +1,13 @@
 package org.zalando.planb.revocation.service.impl;
 
 import com.nimbusds.jwt.JWTParser;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.springframework.stereotype.Component;
 import org.zalando.planb.revocation.api.exception.RevocationUnauthorizedException;
+import org.zalando.planb.revocation.config.properties.CassandraProperties;
+import org.zalando.planb.revocation.config.properties.RevocationProperties;
 import org.zalando.planb.revocation.domain.AuthorizationRule;
 import org.zalando.planb.revocation.domain.ImmutableAuthorizationRule;
 import org.zalando.planb.revocation.domain.RevokedClaimsData;
@@ -19,11 +19,17 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Component
 public class RuleBasedClaimRevocationAuthorizationService extends AbstractAuthorizationService {
 
-    @Autowired
-    private AuthorizationRulesStore authorizationRulesStore;
+    private final AuthorizationRulesStore authorizationRulesStore;
+
+    public RuleBasedClaimRevocationAuthorizationService(
+            AuthorizationRulesStore authorizationRulesStore,
+            RevocationProperties revocationProperties,
+            CassandraProperties cassandraProperties) {
+        super(revocationProperties, cassandraProperties);
+        this.authorizationRulesStore = authorizationRulesStore;
+    }
 
     protected void checkClaimBasedRevocation(final RevokedClaimsData claimsData) {
         final AuthorizationRule sourceRule = ImmutableAuthorizationRule

--- a/src/main/java/org/zalando/planb/revocation/service/impl/SwaggerFromYamlFileService.java
+++ b/src/main/java/org/zalando/planb/revocation/service/impl/SwaggerFromYamlFileService.java
@@ -7,7 +7,6 @@ import java.io.InputStreamReader;
 import java.util.Map;
 
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.yaml.snakeyaml.Yaml;
 import org.zalando.planb.revocation.api.exception.YamlParsingException;
@@ -20,14 +19,14 @@ import org.zalando.planb.revocation.service.SwaggerService;
  */
 public class SwaggerFromYamlFileService implements SwaggerService {
 
-    @Autowired
-    private ApplicationContext context;
+    private final ApplicationContext context;
 
     private final String yamlResource;
 
     private String swaggerJson;
 
-    public SwaggerFromYamlFileService(final String yamlResource) {
+    public SwaggerFromYamlFileService(ApplicationContext context, final String yamlResource) {
+        this.context = context;
         this.yamlResource = yamlResource;
     }
 

--- a/src/main/java/org/zalando/planb/revocation/web/RequestInfoMDCFilter.java
+++ b/src/main/java/org/zalando/planb/revocation/web/RequestInfoMDCFilter.java
@@ -1,14 +1,17 @@
 package org.zalando.planb.revocation.web;
 
 import org.slf4j.MDC;
-import org.springframework.stereotype.Component;
 
-import javax.servlet.*;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Optional;
 
-@Component
 public class RequestInfoMDCFilter implements Filter {
 
     private static final String KEY = "request";

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,10 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.zalando.planb.revocation.config.AopConfig,\
+org.zalando.planb.revocation.config.AwsConfig,\
+org.zalando.planb.revocation.config.CassandraConfig,\
+org.zalando.planb.revocation.config.MetricsConfigurer,\
+org.zalando.planb.revocation.config.PlanBRevocationConfig,\
+org.zalando.planb.revocation.config.RevocationConfig,\
+org.zalando.planb.revocation.config.SecurityConfig,\
+org.zalando.planb.revocation.config.StorageConfig,\
+org.zalando.planb.revocation.config.WebConfig

--- a/src/test/java/exclude/from/componentscan/NoopRevocationAuthorizationConfig.java
+++ b/src/test/java/exclude/from/componentscan/NoopRevocationAuthorizationConfig.java
@@ -4,6 +4,8 @@ package exclude.from.componentscan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.zalando.planb.revocation.config.properties.CassandraProperties;
+import org.zalando.planb.revocation.config.properties.RevocationProperties;
 import org.zalando.planb.revocation.service.RevocationAuthorizationService;
 import org.zalando.planb.revocation.util.security.ClaimRevocationAlwaysAuthorizedService;
 
@@ -12,7 +14,9 @@ public class NoopRevocationAuthorizationConfig {
 
     @Bean
     @Primary
-    public RevocationAuthorizationService revocationAlwaysAuthorizedService() {
-        return new ClaimRevocationAlwaysAuthorizedService();
+    public RevocationAuthorizationService revocationAlwaysAuthorizedService(
+            final RevocationProperties revocationProperties,
+            final CassandraProperties cassandraProperties) {
+        return new ClaimRevocationAlwaysAuthorizedService(revocationProperties, cassandraProperties);
     }
 }

--- a/src/test/java/org/zalando/planb/revocation/config/CassandraConfigIT.java
+++ b/src/test/java/org/zalando/planb/revocation/config/CassandraConfigIT.java
@@ -34,7 +34,8 @@ public class CassandraConfigIT {
                     .web(false)
                     .bannerMode(OFF)
                     .profiles("it")
-                    .run("--cassandra.password=theWrongOne");
+                    .run("--cassandra.password=theWrongOne",
+                            "--logging.level.org.springframework.boot.SpringApplication=OFF");
             failBecauseExceptionWasNotThrown(BeansException.class);
         } catch (BeansException e) {
             assertThat(e).hasRootCauseInstanceOf(AuthenticationException.class);
@@ -47,7 +48,23 @@ public class CassandraConfigIT {
             new SpringApplicationBuilder(CassandraConfig.class)
                     .web(false)
                     .bannerMode(OFF)
-                    .run("--cassandra.contact-points=127.0.0.1");
+                    .run("--cassandra.contact-points=127.0.0.1",
+                            "--logging.level.org.springframework.boot.SpringApplication=OFF");
+            failBecauseExceptionWasNotThrown(BeansException.class);
+        } catch (BeansException e) {
+            assertThat(e).hasRootCauseInstanceOf(AuthenticationException.class);
+        }
+    }
+
+    @Test
+    public void testCassandraConnectionWithMissingPassword() throws Exception {
+        try {
+            new SpringApplicationBuilder(CassandraConfig.class)
+                    .web(false)
+                    .bannerMode(OFF)
+                    .run("--cassandra.contact-points=127.0.0.1",
+                            "--cassandra.username=cassandra",
+                            "--logging.level.org.springframework.boot.SpringApplication=OFF");
             failBecauseExceptionWasNotThrown(BeansException.class);
         } catch (BeansException e) {
             assertThat(e).hasRootCauseInstanceOf(AuthenticationException.class);

--- a/src/test/java/org/zalando/planb/revocation/config/CassandraConfigIT.java
+++ b/src/test/java/org/zalando/planb/revocation/config/CassandraConfigIT.java
@@ -1,0 +1,57 @@
+package org.zalando.planb.revocation.config;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.AuthenticationException;
+import org.junit.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.springframework.boot.Banner.Mode.OFF;
+
+public class CassandraConfigIT {
+
+    @Test
+    public void testSuccessfulCassandraConnection() throws Exception {
+        final ConfigurableApplicationContext applicationContext =
+                new SpringApplicationBuilder(CassandraConfig.class)
+                        .web(false)
+                        .bannerMode(OFF)
+                        .profiles("it")
+                        .run();
+
+        assertThat(applicationContext.getBean(Session.class)).isNotNull();
+
+        applicationContext.close();
+    }
+
+    @Test
+    public void testCassandraConnectionWithBadCredentials() throws Exception {
+        try {
+            new SpringApplicationBuilder(CassandraConfig.class)
+                    .web(false)
+                    .bannerMode(OFF)
+                    .profiles("it")
+                    .run("--cassandra.password=theWrongOne");
+            failBecauseExceptionWasNotThrown(BeansException.class);
+        } catch (BeansException e) {
+            assertThat(e).hasRootCauseInstanceOf(AuthenticationException.class);
+        }
+    }
+
+    @Test
+    public void testCassandraConnectionWithMissingCredentials() throws Exception {
+        try {
+            new SpringApplicationBuilder(CassandraConfig.class)
+                    .web(false)
+                    .bannerMode(OFF)
+                    .run("--cassandra.contact-points=127.0.0.1");
+            failBecauseExceptionWasNotThrown(BeansException.class);
+        } catch (BeansException e) {
+            assertThat(e).hasRootCauseInstanceOf(AuthenticationException.class);
+        }
+    }
+
+}

--- a/src/test/java/org/zalando/planb/revocation/config/SupportCassandraConfig.java
+++ b/src/test/java/org/zalando/planb/revocation/config/SupportCassandraConfig.java
@@ -1,5 +1,6 @@
 package org.zalando.planb.revocation.config;
 
+import com.datastax.driver.core.Session;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -7,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.zalando.planb.revocation.config.properties.CassandraProperties;
 import org.zalando.planb.revocation.persistence.CassandraAuthorizationRuleStore;
-import org.zalando.planb.revocation.persistence.CassandraRevocationStore;
 import org.zalando.planb.revocation.util.persistence.CassandraSupportStore;
 
 /**
@@ -24,18 +24,18 @@ public class SupportCassandraConfig {
     private CassandraProperties cassandraProperties;
 
     @Autowired
-    private StorageConfig storageConfig;
+    private Session session;
 
     @Bean
     public CassandraSupportStore auditStore() {
-        return new CassandraSupportStore(storageConfig.cassandraSession(),
+        return new CassandraSupportStore(session,
                 cassandraProperties.getReadConsistencyLevel(), cassandraProperties.getWriteConsistencyLevel(),
                 cassandraProperties.getMaxTimeDelta());
     }
 
     @Bean
     public CassandraAuthorizationRuleStore cassandraAuthorizationRuleStore() {
-        return new CassandraAuthorizationRuleStore(storageConfig.cassandraSession(), cassandraProperties.getReadConsistencyLevel(),
+        return new CassandraAuthorizationRuleStore(session, cassandraProperties.getReadConsistencyLevel(),
                 cassandraProperties.getWriteConsistencyLevel());
     }
 }

--- a/src/test/java/org/zalando/planb/revocation/management/HealthCheckIT.java
+++ b/src/test/java/org/zalando/planb/revocation/management/HealthCheckIT.java
@@ -1,0 +1,42 @@
+package org.zalando.planb.revocation.management;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.planb.revocation.AbstractSpringIT;
+import org.zalando.planb.revocation.Main;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.RequestEntity.get;
+
+
+@SpringApplicationConfiguration(classes = {Main.class})
+@WebIntegrationTest(randomPort = true)
+public class HealthCheckIT extends AbstractSpringIT {
+
+    private static final ParameterizedTypeReference<Map<String, Object>> HEALTH_TYPE = new ParameterizedTypeReference<Map<String, Object>>() {
+    };
+
+    @Value("${local.management.port}")
+    private int mgmtPort;
+
+    private final RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+
+    @Test
+    public void testGetHealth() throws Exception {
+        final Map<String, Object> health = restTemplate.exchange(
+                get(URI.create("http://localhost:" + mgmtPort + "/health"))
+                        .accept(APPLICATION_JSON).build(),
+                HEALTH_TYPE)
+                .getBody();
+        assertThat(health).containsKey("cassandra");
+    }
+}

--- a/src/test/java/org/zalando/planb/revocation/management/HealthCheckIT.java
+++ b/src/test/java/org/zalando/planb/revocation/management/HealthCheckIT.java
@@ -1,42 +1,84 @@
 package org.zalando.planb.revocation.management;
 
+import com.datastax.driver.core.Session;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.WebIntegrationTest;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
-import org.zalando.planb.revocation.AbstractSpringIT;
 import org.zalando.planb.revocation.Main;
 
 import java.net.URI;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.RequestEntity.get;
+import static org.springframework.test.annotation.DirtiesContext.MethodMode.AFTER_METHOD;
 
 
 @SpringApplicationConfiguration(classes = {Main.class})
-@WebIntegrationTest(randomPort = true)
-public class HealthCheckIT extends AbstractSpringIT {
+@WebIntegrationTest(randomPort = true, value = "endpoints.health.time-to-live=0")
+@ActiveProfiles("it")
+public class HealthCheckIT {
 
     private static final ParameterizedTypeReference<Map<String, Object>> HEALTH_TYPE = new ParameterizedTypeReference<Map<String, Object>>() {
     };
 
-    @Value("${local.management.port}")
-    private int mgmtPort;
+    @ClassRule
+    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
+
+    @Rule
+    public final SpringMethodRule methodRule = new SpringMethodRule();
 
     private final RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
 
+    @Value("${local.management.port}")
+    private int mgmtPort;
+
+    @Autowired
+    private Session session;
+
+    // the test will break the cassandra session
+    @DirtiesContext(methodMode = AFTER_METHOD)
     @Test
     public void testGetHealth() throws Exception {
-        final Map<String, Object> health = restTemplate.exchange(
+
+        // first health check should succeed
+        final Map<String, Object> health = pollHealth();
+        assertThat(health).containsKey("cassandra");
+
+        // destroy cassandra connection
+        session.close();
+
+        // second health check should fail
+        try {
+            pollHealth();
+            failBecauseExceptionWasNotThrown(HttpServerErrorException.class);
+        } catch (HttpServerErrorException e) {
+            System.out.println(e.getResponseBodyAsString());
+            assertThat(e.getStatusCode()).isEqualTo(SERVICE_UNAVAILABLE);
+        }
+    }
+
+    private Map<String, Object> pollHealth() {
+        return restTemplate.exchange(
                 get(URI.create("http://localhost:" + mgmtPort + "/health"))
                         .accept(APPLICATION_JSON).build(),
                 HEALTH_TYPE)
                 .getBody();
-        assertThat(health).containsKey("cassandra");
     }
+
 }

--- a/src/test/java/org/zalando/planb/revocation/util/persistence/CassandraSupportStore.java
+++ b/src/test/java/org/zalando/planb/revocation/util/persistence/CassandraSupportStore.java
@@ -20,7 +20,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.gt;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -148,6 +150,10 @@ public class CassandraSupportStore {
      */
     public String getCreatedBy() {
         int yearBucket = LocalDate.now(ZoneId.of("UTC")).getYear();
+
+        // TODO remove this
+        System.out.println(yearBucket);
+        System.out.println("\n\n\n" + session.execute("SELECT * FROM refresh;").all() + "\n\n");
 
         // TODO Include the case when it's the beginning of the year (2 buckets needed)
         ResultSet rs = session.execute(getCreatedBy.bind(yearBucket));

--- a/src/test/java/org/zalando/planb/revocation/util/persistence/CassandraSupportStore.java
+++ b/src/test/java/org/zalando/planb/revocation/util/persistence/CassandraSupportStore.java
@@ -151,10 +151,6 @@ public class CassandraSupportStore {
     public String getCreatedBy() {
         int yearBucket = LocalDate.now(ZoneId.of("UTC")).getYear();
 
-        // TODO remove this
-        System.out.println(yearBucket);
-        System.out.println("\n\n\n" + session.execute("SELECT * FROM refresh;").all() + "\n\n");
-
         // TODO Include the case when it's the beginning of the year (2 buckets needed)
         ResultSet rs = session.execute(getCreatedBy.bind(yearBucket));
 

--- a/src/test/java/org/zalando/planb/revocation/util/security/ClaimRevocationAlwaysAuthorizedService.java
+++ b/src/test/java/org/zalando/planb/revocation/util/security/ClaimRevocationAlwaysAuthorizedService.java
@@ -1,9 +1,17 @@
 package org.zalando.planb.revocation.util.security;
 
+import org.zalando.planb.revocation.config.properties.CassandraProperties;
+import org.zalando.planb.revocation.config.properties.RevocationProperties;
 import org.zalando.planb.revocation.domain.RevokedClaimsData;
 import org.zalando.planb.revocation.service.impl.AbstractAuthorizationService;
 
-public class ClaimRevocationAlwaysAuthorizedService extends AbstractAuthorizationService{
+public class ClaimRevocationAlwaysAuthorizedService extends AbstractAuthorizationService {
+
+    public ClaimRevocationAlwaysAuthorizedService(
+            final RevocationProperties revocationProperties,
+            final CassandraProperties cassandraProperties) {
+        super(revocationProperties, cassandraProperties);
+    }
 
     @Override
     protected void checkClaimBasedRevocation(RevokedClaimsData claimsData) {

--- a/src/test/resources/META-INF/spring.factories
+++ b/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.zalando.planb.revocation.config.SupportCassandraConfig,\
+org.zalando.planb.revocation.config.CassandraTestAddressTranslatorConfig

--- a/src/test/resources/config/application-it.yml
+++ b/src/test/resources/config/application-it.yml
@@ -9,4 +9,5 @@ cassandra:
 logging:
   level:
     org.zalando.planb: DEBUG
-    com.datastax.driver: TRACE
+    org.springframework.context: DEBUG
+    org.springframework.boot.autoconfigure: DEBUG

--- a/src/test/resources/config/application-it.yml
+++ b/src/test/resources/config/application-it.yml
@@ -11,5 +11,3 @@ cassandra:
 logging:
   level:
     org.zalando.planb: DEBUG
-    org.springframework.context: DEBUG
-    org.springframework.boot.autoconfigure: DEBUG

--- a/src/test/resources/config/application-it.yml
+++ b/src/test/resources/config/application-it.yml
@@ -5,6 +5,8 @@ spring:
 cassandra:
   contactPoints: 127.0.0.1
   clusterName: Local Cluster
+  username: cassandra
+  password: cassandra
 
 logging:
   level:

--- a/src/test/resources/config/application-it.yml
+++ b/src/test/resources/config/application-it.yml
@@ -3,6 +3,7 @@ spring:
     include: test
 
 cassandra:
+  health-check-query: "SELECT release_version FROM system.local;"
   contactPoints: 127.0.0.1
   clusterName: Local Cluster
   username: cassandra

--- a/src/test/resources/config/application-it.yml
+++ b/src/test/resources/config/application-it.yml
@@ -9,3 +9,4 @@ cassandra:
 logging:
   level:
     org.zalando.planb: DEBUG
+    com.datastax.driver: TRACE


### PR DESCRIPTION
fixes #52 

Well, this PR got bigger than I planned ;-)
I started using the `@ConditionalOn...` annotation of Spring Boot, to create a cleaner configuration. See `CassandraConfig` and `StorageConfig` (and its two inner classes) for example.
However I struggled with the order in which the conditions were evaluated and found out, that `@AutoconfigureAfter` does only work when used with spring.factories (instead of component-scanning all `@Configuration` beans). Thus I decided to remove the global `@ComponentScan` and introduced the `META-INF/spring.factories` file, which contains a list of config classes that should be picked up by `@EnableAutoConfiguration`. This is my opinion, the cleaner way of constructing a Spring context and it eliminates the errors that came from accidentally picked up test config classes.

But of course I also handled the initial issue #52 and introduced the CassandraHealthIndicator as well as a bunch of tests: `CassandraConfigIT`, `HealthCheckIT` to show what happens if wrong credentials are provided or the app gets disconnected from Cassandra.