### PR TITLE
#113 Allow defining multiple Token Info endpoints as fallback

### DIFF
--- a/src/main/java/org/zalando/planb/revocation/config/FallbackTokenInfoRequestExecutor.java
+++ b/src/main/java/org/zalando/planb/revocation/config/FallbackTokenInfoRequestExecutor.java
@@ -1,0 +1,55 @@
+package org.zalando.planb.revocation.config;
+
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestClientException;
+import org.zalando.stups.oauth2.spring.server.DefaultTokenInfoRequestExecutor;
+import org.zalando.stups.oauth2.spring.server.TokenInfoRequestExecutor;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Executor that allows several tokeninfo endpoints separated by "|", then requests
+ * by order of definition in the string, and if an error happens, falls-back to the next one.
+ *
+ * @author vroldanbetan
+ *
+ */
+public class FallbackTokenInfoRequestExecutor implements TokenInfoRequestExecutor {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final static String URI_SEPARATOR = "\\,";
+
+    private List<TokenInfoRequestExecutor> executors;
+
+    public FallbackTokenInfoRequestExecutor(final String tokenInfoEndpointUrl) {
+        executors = buildExecutorsFromMultipleURLs(tokenInfoEndpointUrl);
+    }
+
+    private List<TokenInfoRequestExecutor> buildExecutorsFromMultipleURLs(String tokenInfoEndpointUrl) {
+        final List<TokenInfoRequestExecutor> tokenInfoRequestExecutors = new ArrayList<>();
+        for (String endpoint : tokenInfoEndpointUrl.split(URI_SEPARATOR)) {
+            tokenInfoRequestExecutors.add(new DefaultTokenInfoRequestExecutor(endpoint.trim()));
+        }
+        return ImmutableList.copyOf(tokenInfoRequestExecutors);
+    }
+
+    @Override
+    public Map<String, Object> getMap(String accessToken) {
+        RuntimeException cachedException = new IllegalArgumentException("Could not validate token");
+        for (TokenInfoRequestExecutor executor : executors) {
+            try {
+                return executor.getMap(accessToken);
+            } catch (RestClientException ex) {
+                log.warn(MessageFormat.format("Token info request failed: {0}", ex.getMessage()));
+                cachedException = ex;
+            }
+        }
+        throw cachedException;
+    }
+}

--- a/src/main/java/org/zalando/planb/revocation/config/SecurityConfig.java
+++ b/src/main/java/org/zalando/planb/revocation/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.zalando.planb.revocation.config.properties.ApiSecurityProperties;
 import org.zalando.planb.revocation.domain.CurrentUser;
 import org.zalando.stups.oauth2.spring.security.expression.ExtendedOAuth2WebSecurityExpressionHandler;
+import org.zalando.stups.oauth2.spring.server.DefaultAuthenticationExtractor;
 import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
 
 import java.util.concurrent.TimeUnit;
@@ -39,7 +40,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter implements Reso
 
     @Bean
     public ResourceServerTokenServices tokenInfoTokenServices() {
-        return new TokenInfoResourceServerTokenServices(resourceServerProperties.getTokenInfoUri());
+        return new TokenInfoResourceServerTokenServices("CLIENT_ID_NOT_NEEDED",
+                new DefaultAuthenticationExtractor(),
+                new FallbackTokenInfoRequestExecutor(resourceServerProperties.getTokenInfoUri()));
     }
 
     @Override

--- a/src/test/java/org/zalando/planb/revocation/AbstractOAuthTest.java
+++ b/src/test/java/org/zalando/planb/revocation/AbstractOAuthTest.java
@@ -1,0 +1,168 @@
+package org.zalando.planb.revocation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.ImmutableMap;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.planb.revocation.domain.*;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+/**
+ * @author jbellmann
+ */
+public class AbstractOAuthTest {
+    public static final String SAMPLE_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            + ".eyJzdWIiOiIxIiwibmFtZSI6InJyZWlzIiwiYWRtaW4iOnRydWV9.UlZhyvrY9e7tRU88l8sfRb37oWGiL2t4insnO9Nsn1c";
+    public static final String SAMPLE_TOKEN_2 = "eyJraWQiOiJ0ZXN0a2V5LWVzMjU2IiwiYWxnIjoiRVMyNTYifQ" +
+            ".eyJzdWIiOiJ0ZXN0MCIsInNjb3BlIjpbInVpZCIsImNuIl0sImlzcyI6IkIiLCJyZWFsbSI6Ii9zZXJ2aWNlcyIsImV4cCI6MTQ1OTk3MzMyOSwiaWF0IjoxNDU5OTQ0NTI5fQ" +
+            ".Vo8_jbqCET31ej1iLAlcQFc2FzArzQrQwDY3c34keKhpJoDQoHVOX-pqjiM5J_Tp0p13HNZbB3-O4o0U2d2LzA";
+    public static final String VALID_ACCESS_TOKEN = "Bearer " + SAMPLE_TOKEN_2;
+    public static final String INVALID_ACCESS_TOKEN = "Bearer 987654321";
+    public static final String INSUFFICIENT_SCOPES_ACCESS_TOKEN = "Bearer 123456";
+    public static final String SERVER_ERROR_ACCESS_TOKEN = "Bearer 500";
+
+    public static final String TOKENINFO_RESPONSE = "{\n" + "    \"uid\": \"testapp\",\n" + "    \"scope\": [\n"
+            + "        \"uid\",\n" + "        \"token.revoke\"\n" + "    ],\n" + "    \"hello\": \"World\",\n"
+            + "    \"expires_in\": 99999,\n" + "    \"token_type\": \"Bearer\",\n"
+            + "    \"access_token\": \"" + SAMPLE_TOKEN_2 + "\",\n" + "    \"realm\": \"/services\"\n" + "}";
+
+    public static final String TOKENINFO_RESPONSE_INSUFFICIENT_SCOPES = "{\n" + "    \"uid\": \"testapp\",\n"
+            + "    \"scope\": [\n" + "        \"uid\"\n" + "    ],\n" + "    \"expires_in\": 99999,\n"
+            + "    \"token_type\": \"Bearer\",\n" + "    \"access_token\": \"987654321\",\n"
+            + "    \"realm\": \"/services\"\n" + "}";
+
+    public static final String EXPIRED_ACCESS_TOKEN_RESPONSE = "{\n" + "    \"error\": \"invalid_request\",\n"
+            + "    \"error_description\": \"Access Token not valid\"\n" + "}";
+
+
+    private RestTemplate restTemplate;
+
+    @Autowired(required = false)
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(Integer.valueOf(System.getProperty("wiremock.port", "10080")));
+
+    @Before
+    public void setUpTest() {
+        prepareTokenInfoMock();
+        prepareRestTemplate();
+        configureJsonPath();
+    }
+
+    /*
+     * Do not use default JsonSmart provider, instead use Jackson.
+     */
+    private void configureJsonPath() {
+        Configuration.setDefaults(new Configuration.Defaults() {
+
+            private final JsonProvider jsonProvider = new JacksonJsonProvider();
+            private final MappingProvider mappingProvider = new JacksonMappingProvider();
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return jsonProvider;
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return mappingProvider;
+            }
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+        });
+    }
+
+    private void prepareTokenInfoMock() {
+        stubFor(get(urlEqualTo("/tokeninfo")).withHeader(HttpHeaders.AUTHORIZATION, equalTo(VALID_ACCESS_TOKEN))
+                .willReturn(
+                        aResponse().withStatus(HttpStatus.OK.value()).withHeader(ContentTypeHeader.KEY,
+                                MediaType.APPLICATION_JSON_VALUE).withBody(TOKENINFO_RESPONSE)));
+
+        stubFor(get(urlEqualTo("/tokeninfo")).withHeader(HttpHeaders.AUTHORIZATION, equalTo(INVALID_ACCESS_TOKEN))
+                .willReturn(
+                        aResponse().withStatus(HttpStatus.BAD_REQUEST.value()).withHeader(ContentTypeHeader.KEY,
+                                MediaType.APPLICATION_JSON_VALUE).withBody(EXPIRED_ACCESS_TOKEN_RESPONSE)));
+
+        stubFor(get(urlEqualTo("/tokeninfo")).withHeader(HttpHeaders.AUTHORIZATION,
+                equalTo(INSUFFICIENT_SCOPES_ACCESS_TOKEN)).willReturn(
+                aResponse().withStatus(HttpStatus.OK.value()).withHeader(ContentTypeHeader.KEY,
+                        MediaType.APPLICATION_JSON_VALUE).withBody(TOKENINFO_RESPONSE_INSUFFICIENT_SCOPES)));
+
+        stubFor(get(urlEqualTo("/tokeninfo")).withHeader(HttpHeaders.AUTHORIZATION,
+                equalTo(SERVER_ERROR_ACCESS_TOKEN)).willReturn(
+                aResponse().withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())));
+    }
+
+    private void prepareRestTemplate() {
+        restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+
+        /*
+         * We need to replace the default object mapper with ours object mapper so it reads lower case with
+         * underscores correctly.
+         */
+        for (int i = 0; i < restTemplate.getMessageConverters().size(); i++) {
+            if (restTemplate.getMessageConverters().get(i) instanceof MappingJackson2HttpMessageConverter) {
+                restTemplate.getMessageConverters().set(i, new MappingJackson2HttpMessageConverter(objectMapper));
+            }
+        }
+    }
+
+    protected RestTemplate getRestTemplate() {
+        return restTemplate;
+    }
+
+    // Some utility methods
+    public static RevocationRequest generateClaimBasedRevocation(Map<String, String> claims) {
+        return ImmutableRevocationRequest.builder()
+                .type(RevocationType.CLAIM)
+                .data(ImmutableRevokedClaimsData.builder().putAllClaims(claims).build())
+                .build();
+    }
+
+    public static RevocationRequest generateRevocation(final RevocationType type) {
+
+        RevokedData data = null;
+        switch (type) {
+
+            case TOKEN:
+                data = ImmutableRevokedTokenData.builder().token(SAMPLE_TOKEN).build();
+                break;
+
+            case CLAIM:
+                return generateClaimBasedRevocation(ImmutableMap.of("uid", "rreis", "sub", "abcd"));
+
+            case GLOBAL:
+                data = ImmutableRevokedGlobal.builder().build();
+                break;
+        }
+
+        return ImmutableRevocationRequest.builder()
+                .type(type)
+                .data(data)
+                .build();
+    }
+}

--- a/src/test/java/org/zalando/planb/revocation/AbstractSpringTest.java
+++ b/src/test/java/org/zalando/planb/revocation/AbstractSpringTest.java
@@ -1,188 +1,19 @@
 package org.zalando.planb.revocation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.collect.ImmutableMap;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
-import com.jayway.jsonpath.spi.json.JsonProvider;
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
-import com.jayway.jsonpath.spi.mapper.MappingProvider;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
-import org.springframework.web.client.RestTemplate;
-import org.zalando.planb.revocation.domain.ImmutableRevocationRequest;
-import org.zalando.planb.revocation.domain.ImmutableRevokedClaimsData;
-import org.zalando.planb.revocation.domain.ImmutableRevokedGlobal;
-import org.zalando.planb.revocation.domain.ImmutableRevokedTokenData;
-import org.zalando.planb.revocation.domain.RevocationRequest;
-import org.zalando.planb.revocation.domain.RevocationType;
-import org.zalando.planb.revocation.domain.RevokedData;
-
-import java.util.EnumSet;
-import java.util.Map;
-import java.util.Set;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 
 /**
  * @author jbellmann
  */
-public abstract class AbstractSpringTest {
-
-    public static final String SAMPLE_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-            + ".eyJzdWIiOiIxIiwibmFtZSI6InJyZWlzIiwiYWRtaW4iOnRydWV9.UlZhyvrY9e7tRU88l8sfRb37oWGiL2t4insnO9Nsn1c";
-    public static final String SAMPLE_TOKEN_2 = "eyJraWQiOiJ0ZXN0a2V5LWVzMjU2IiwiYWxnIjoiRVMyNTYifQ" +
-            ".eyJzdWIiOiJ0ZXN0MCIsInNjb3BlIjpbInVpZCIsImNuIl0sImlzcyI6IkIiLCJyZWFsbSI6Ii9zZXJ2aWNlcyIsImV4cCI6MTQ1OTk3MzMyOSwiaWF0IjoxNDU5OTQ0NTI5fQ" +
-            ".Vo8_jbqCET31ej1iLAlcQFc2FzArzQrQwDY3c34keKhpJoDQoHVOX-pqjiM5J_Tp0p13HNZbB3-O4o0U2d2LzA";
-    public static final String VALID_ACCESS_TOKEN = "Bearer " + SAMPLE_TOKEN_2;
-    public static final String INVALID_ACCESS_TOKEN = "Bearer 987654321";
-    public static final String INSUFFICIENT_SCOPES_ACCESS_TOKEN = "Bearer 123456";
-    public static final String SERVER_ERROR_ACCESS_TOKEN = "Bearer 500";
-
-    public static final String TOKENINFO_RESPONSE = "{\n" + "    \"uid\": \"testapp\",\n" + "    \"scope\": [\n"
-            + "        \"uid\",\n" + "        \"token.revoke\"\n" + "    ],\n" + "    \"hello\": \"World\",\n"
-            + "    \"expires_in\": 99999,\n" + "    \"token_type\": \"Bearer\",\n"
-            + "    \"access_token\": \"" + SAMPLE_TOKEN_2 + "\",\n" + "    \"realm\": \"/services\"\n" + "}";
-
-    public static final String TOKENINFO_RESPONSE_INSUFFICIENT_SCOPES = "{\n" + "    \"uid\": \"testapp\",\n"
-            + "    \"scope\": [\n" + "        \"uid\"\n" + "    ],\n" + "    \"expires_in\": 99999,\n"
-            + "    \"token_type\": \"Bearer\",\n" + "    \"access_token\": \"987654321\",\n"
-            + "    \"realm\": \"/services\"\n" + "}";
-
-    public static final String EXPIRED_ACCESS_TOKEN_RESPONSE = "{\n" + "    \"error\": \"invalid_request\",\n"
-            + "    \"error_description\": \"Access Token not valid\"\n" + "}";
-
-
-    private RestTemplate restTemplate;
-
-    @Autowired(required = false)
-    private ObjectMapper objectMapper = new ObjectMapper();
-
-    @Rule
-    public WireMockRule wireMock = new WireMockRule(Integer.valueOf(System.getProperty("wiremock.port", "10080")));
-
-    @Rule
-    public SpringMethodRule methodRule = new SpringMethodRule();
+public abstract class AbstractSpringTest extends AbstractOAuthTest {
 
     @ClassRule
     public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
 
-    @Before
-    public void setUpTest() {
-        prepareTokenInfoMock();
-        prepareRestTemplate();
-        configureJsonPath();
-    }
+    @Rule
+    public SpringMethodRule methodRule = new SpringMethodRule();
 
-    /*
-     * Do not use default JsonSmart provider, instead use Jackson.
-     */
-    private void configureJsonPath() {
-        Configuration.setDefaults(new Configuration.Defaults() {
-
-            private final JsonProvider jsonProvider = new JacksonJsonProvider();
-            private final MappingProvider mappingProvider = new JacksonMappingProvider();
-
-            @Override
-            public JsonProvider jsonProvider() {
-                return jsonProvider;
-            }
-
-            @Override
-            public MappingProvider mappingProvider() {
-                return mappingProvider;
-            }
-
-            @Override
-            public Set<Option> options() {
-                return EnumSet.noneOf(Option.class);
-            }
-        });
-    }
-
-    private void prepareTokenInfoMock() {
-        stubFor(get(urlEqualTo("/tokeninfo")).withHeader(HttpHeaders.AUTHORIZATION, equalTo(VALID_ACCESS_TOKEN))
-                .willReturn(
-                        aResponse().withStatus(HttpStatus.OK.value()).withHeader(ContentTypeHeader.KEY,
-                                MediaType.APPLICATION_JSON_VALUE).withBody(TOKENINFO_RESPONSE)));
-
-        stubFor(get(urlEqualTo("/tokeninfo")).withHeader(HttpHeaders.AUTHORIZATION, equalTo(INVALID_ACCESS_TOKEN))
-                .willReturn(
-                        aResponse().withStatus(HttpStatus.BAD_REQUEST.value()).withHeader(ContentTypeHeader.KEY,
-                                MediaType.APPLICATION_JSON_VALUE).withBody(EXPIRED_ACCESS_TOKEN_RESPONSE)));
-
-        stubFor(get(urlEqualTo("/tokeninfo")).withHeader(HttpHeaders.AUTHORIZATION,
-                equalTo(INSUFFICIENT_SCOPES_ACCESS_TOKEN)).willReturn(
-                aResponse().withStatus(HttpStatus.OK.value()).withHeader(ContentTypeHeader.KEY,
-                        MediaType.APPLICATION_JSON_VALUE).withBody(TOKENINFO_RESPONSE_INSUFFICIENT_SCOPES)));
-
-        stubFor(get(urlEqualTo("/tokeninfo")).withHeader(HttpHeaders.AUTHORIZATION,
-                equalTo(SERVER_ERROR_ACCESS_TOKEN)).willReturn(
-                aResponse().withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())));
-    }
-
-    private void prepareRestTemplate() {
-        restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
-
-        /*
-         * We need to replace the default object mapper with ours object mapper so it reads lower case with
-         * underscores correctly.
-         */
-        for (int i = 0; i < restTemplate.getMessageConverters().size(); i++) {
-            if (restTemplate.getMessageConverters().get(i) instanceof MappingJackson2HttpMessageConverter) {
-                restTemplate.getMessageConverters().set(i, new MappingJackson2HttpMessageConverter(objectMapper));
-            }
-        }
-    }
-
-    protected RestTemplate getRestTemplate() {
-        return restTemplate;
-    }
-
-    // Some utility methods
-    public static RevocationRequest generateClaimBasedRevocation(Map<String, String> claims) {
-        return ImmutableRevocationRequest.builder()
-                .type(RevocationType.CLAIM)
-                .data(ImmutableRevokedClaimsData.builder().putAllClaims(claims).build())
-                .build();
-    }
-
-    public static RevocationRequest generateRevocation(final RevocationType type) {
-
-        RevokedData data = null;
-        switch (type) {
-
-            case TOKEN:
-                data = ImmutableRevokedTokenData.builder().token(SAMPLE_TOKEN).build();
-                break;
-
-            case CLAIM:
-                return generateClaimBasedRevocation(ImmutableMap.of("uid", "rreis", "sub", "abcd"));
-
-            case GLOBAL:
-                data = ImmutableRevokedGlobal.builder().build();
-                break;
-        }
-
-        return ImmutableRevocationRequest.builder()
-                .type(type)
-                .data(data)
-                .build();
-    }
 }

--- a/src/test/java/org/zalando/planb/revocation/config/FallbackTokenInfoRequestExecutorTest.java
+++ b/src/test/java/org/zalando/planb/revocation/config/FallbackTokenInfoRequestExecutorTest.java
@@ -1,0 +1,45 @@
+package org.zalando.planb.revocation.config;
+
+import org.junit.Test;
+import org.springframework.web.client.HttpClientErrorException;
+import org.zalando.planb.revocation.AbstractOAuthTest;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FallbackTokenInfoRequestExecutorTest extends AbstractOAuthTest {
+
+    private Integer wireMockPort = Integer.valueOf(System.getProperty("wiremock.port", "10080"));
+
+    @Test
+    public void testSingleEndpointValidToken() {
+        FallbackTokenInfoRequestExecutor executor =
+                new FallbackTokenInfoRequestExecutor("http://localhost:" + wireMockPort + "/tokeninfo");
+        Map<String, Object> result = executor.getMap(SAMPLE_TOKEN_2);
+        assertThat(result).hasSize(7);
+    }
+
+    @Test(expected = HttpClientErrorException.class)
+    public void testSingleEndpointInvalidToken() {
+        FallbackTokenInfoRequestExecutor executor =
+                new FallbackTokenInfoRequestExecutor("http://localhost:" + wireMockPort + "/tokeninfo");
+        executor.getMap(INVALID_ACCESS_TOKEN);
+    }
+
+    @Test
+    public void testFallbackToSecondEndpointValidToken() {
+        FallbackTokenInfoRequestExecutor executor =
+                new FallbackTokenInfoRequestExecutor("http://foobar:5212/tokeninfo, http://localhost:" + wireMockPort + "/tokeninfo");
+        Map<String, Object> result = executor.getMap(SAMPLE_TOKEN_2);
+        assertThat(result).hasSize(7);
+    }
+
+    @Test(expected = HttpClientErrorException.class)
+    public void testFallbackToSecondEndpointInvalidToken() {
+        FallbackTokenInfoRequestExecutor executor =
+                new FallbackTokenInfoRequestExecutor("http://foobar:5212/tokeninfo, http://localhost:" + wireMockPort + "/tokeninfo");
+        executor.getMap(INVALID_ACCESS_TOKEN);
+    }
+
+}


### PR DESCRIPTION
- Introduced FallbackTokenInfoRequestExecutor
- Changed SecurityConfig to use the new executor
- Refactored AbstractSpringTest for non-spring tests into AbstractOAuthTest